### PR TITLE
fix: Properly handle node deprecation warning

### DIFF
--- a/deprecation-warning
+++ b/deprecation-warning
@@ -2,7 +2,7 @@
   "name": "node-postmates",
   "version": "1.9.1",
   "description": "Node.js wrapper for the Postmates API",
-  "main": "lib/index.js",
+  "main": "index.js",
   "scripts": {
     "test": "mocha test/*.js --delay 800 --timeout 5000",
     "prepare": "node_modules/babel-cli/bin/babel.js src --out-dir lib"


### PR DESCRIPTION
```
[DEP0128] DeprecationWarning: Invalid 'main' field in '/app/node_modules/node-postmates/package.json' of 'lib/index.js'. Please either fix that or report it to the module author
```